### PR TITLE
feat(filesystem): added figfind.filesystem module

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,3 @@
-[mypy]
-files=figfind
-ignore_missing_imports=true
-
 [flake8]
 ignore = E203, E266, F403, E501, W503
 max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v0.910
     hooks:
     -   id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports]
+        args: [--no-strict-optional, --ignore-missing-imports, --python-version, '3.10']
 -   repo: https://github.com/PyCQA/isort # sorts imports
     rev: '5.10.1'
     hooks:

--- a/figfind/filesystem.py
+++ b/figfind/filesystem.py
@@ -1,0 +1,15 @@
+import os
+import pathlib
+
+
+def config_path(filename: str = "") -> pathlib.Path:
+    xdg_config_path = _expanded_path(os.environ.get("XDG_CONFIG_HOME", "~/.config"))
+    return xdg_config_path / filename
+
+
+def _is_valid_filesystem():
+    return os.name == "posix"
+
+
+def _expanded_path(path: str | pathlib.Path) -> pathlib.Path:
+    return pathlib.Path(path).expanduser()

--- a/poetry.lock
+++ b/poetry.lock
@@ -431,6 +431,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.6.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -538,7 +552,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "2130b569d515e5f0dde6c98253b7d9e2d7f07480dd52d37ead9be344976602a9"
+content-hash = "ca7310287eb5682d33df494642277eb0d126c93aa9d37c219e26acd4872a3ce2"
 
 [metadata.files]
 argcomplete = [
@@ -821,6 +835,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
+    {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,8 @@ line-length = 88
 profile = "black"
 line_length = 88
 skip_gitignore = true
+
+[mypy]
+python_version = "3.10"
+files= "figfind"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ mypy = "^0.910"
 isort = "^5.10.1"
 flake8 = "^4.0.1"
 blacken-docs = "^1.11.0"
+pytest-mock = "^3.6.1"
+
 
 [tool.poetry.scripts]
 figfind = 'figfind.cli:run'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,13 @@
 """
 PyTest Fixtures.
 """
+import pytest
 
-# import pytest
+import figfind.filesystem  # noqa: F401
 
-# from cement import fs
 
-# @pytest.fixture(scope="function")
-# def tmp(request):
-#     """
-#     Create a `tmp` object that geneates a unique temporary directory, and file
-#     for each test function that requires it.
-#     """
-#     t = fs.Tmp()
-#     yield t
-#     t.remove()
+@pytest.fixture(scope="function")
+def mock_os(mocker):
+    """Mock builtin os calls in figfind.file_system."""
+    mock_os = mocker.patch("figfind.filesystem.os")
+    yield mock_os

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,33 @@
+import pathlib
+
+import pytest  # noqa: F401
+
+from figfind.filesystem import _expanded_path, _is_valid_filesystem, config_path
+
+
+def test_is_valid_filesystem(mock_os):
+    mock_os.name = "posix"
+    assert _is_valid_filesystem()
+
+    mock_os.name = "nt"
+    assert not _is_valid_filesystem()
+
+
+def test_expand_path_same_with_string_and_with_path():
+    fake_path = "/etc"
+    assert _expanded_path(fake_path) == _expanded_path(pathlib.Path(fake_path))
+
+
+def test_config_path_no_file(mock_os):
+    config_dir = ".config"
+    mock_os.environ = {"XDG_CONFIG_HOME": f"~/{config_dir}"}
+    path = pathlib.Path.home() / config_dir
+    assert config_path() == path
+
+
+def test_config_path_with_file(mock_os):
+    config_dir = ".config"
+    mock_os.environ = {"XDG_CONFIG_HOME": f"~/{config_dir}"}
+    filename = "filename"
+    path_with_file = pathlib.Path.home() / config_dir / filename
+    assert config_path(filename) == path_with_file


### PR DESCRIPTION
- Adds `figfind.filesystem` module
- In the module, adds and tests the function `config_path`, `_is_valid_filesystem`, and `_expanded_path`
- adds `tests/conftest.py` for fixtures (specifically, I mock the `os` module)
- refactors `setup.cfg` into `.flake8`, and moves the mypy config out of it and into `pyproject.toml` 